### PR TITLE
invalid versionCode

### DIFF
--- a/src/main/resources/addon.json
+++ b/src/main/resources/addon.json
@@ -2,5 +2,5 @@
   "name":"Particle Addon",
   "version":"1.2",
   "mainClass":"net.chachy.particlemod.ParticleMod",
-  "versionCode": "1.2"
+  "versionCode": "1.0"
 }


### PR DESCRIPTION
versionCode is meant to line up with the one inside of [AddonMinecraftBootstrap#VERSION_CODE](https://github.com/HyperiumClient/Hyperium/blob/08efed520cbca3ef041df923839cff9524b3cd9f/src/main/kotlin/cc/hyperium/internal/addons/AddonMinecraftBootstrap.kt#L49), not your own